### PR TITLE
[hotfix] handling when aws_region and aws_default_region not equal

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,6 +43,9 @@ if [[ 1 -gt "$(cat $GITHUB_ENV | grep -c AWS_DEFAULT_REGION)" ]]; then
     echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" >> "$GITHUB_ENV"
 fi
 if [[ 1 -gt "$(cat $GITHUB_ENV | grep -c AWS_REGION)" ]]; then
-    AWS_REGION="${AWS_REGION:=$AWS_DEFAULT_REGION}"
-    echo "AWS_REGION=$AWS_REGION" >> "$GITHUB_ENV"
+    if [[ "$AWS_DEFAULT_REGION" != "$AWS_REGION" ]]; then
+        echo "AWS_REGION=$AWS_DEFAULT_REGION" >> "$GITHUB_ENV"
+    else
+        echo "AWS_REGION=$AWS_REGION" >> "$GITHUB_ENV"
+    fi
 fi


### PR DESCRIPTION
# Description

CI fails when AWS_REGION and AWS_DEFAULT_REGION differ.
Forcing AWS_REGION to be AWS_DEFAULT_REGION if they differ. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Pre reqs:
  - use actions-setup branch `uses: variant-inc/actions-setup@hotfix/aws-region-defaulting`

Test Case 1 [AWS_DEFAULT_REGION=us-east-2, AWS_REGION unset]:
- Steps
  - set env variables in the workflow, commit & push
```
  env:
    #AWS_REGION: us-east-1
    AWS_DEFAULT_REGION: us-east-2
```

- Result
  - build will succeed
  - https://github.com/variant-inc/demo-python-flask-variant-api/runs/7218510811?check_suite_focus=true
  - image is pushed to us-east-2

Test Case 2 [both AWS_REGION and AWS_DEFAULT_REGION unset]:
- Steps
  - unset env variables in the workflow, commit & push
```
  env:
    #AWS_REGION: us-east-1
    #AWS_DEFAULT_REGION: us-east-2
```

- Result
  - build will succeed
  - https://github.com/variant-inc/demo-python-flask-variant-api/runs/7218613055?check_suite_focus=true
  - image is pushed to us-east-1

Test Case 3 [(when the 2 env vars differ,force both to be AWS_DEFAULT_REGION) AWS_REGION=us-east-2, AWS_DEFAULT_REGION unset]:
- Steps
  - set env variables in the workflow, commit & push
```
  env:
    AWS_REGION: us-east-2
    #AWS_DEFAULT_REGION: us-east-2
```
- Result
  - build will succeed
  - https://github.com/variant-inc/demo-python-flask-variant-api/runs/7218663918?check_suite_focus=true
  - image is pushed to *us-east-1*

Test Case 4 [(when the 2 env vars differ) AWS_REGION=us-east-1, AWS_DEFAULT_REGION=us-east-2]:
- Steps
  - set env variables in the workflow, commit & push
```
  env:
    AWS_REGION: us-east-1
    AWS_DEFAULT_REGION: us-east-2
```
- Result
  - build will succeed
  - https://github.com/variant-inc/demo-python-flask-variant-api/runs/7218728720?check_suite_focus=true
  - image is pushed to *us-east-2*

Test Case 5 [AWS_REGION=us-east-2, AWS_DEFAULT_REGION=us-east-2]:
- Steps
  - set env variables in the workflow, commit & push
```
  env:
    AWS_REGION: us-east-2
    AWS_DEFAULT_REGION: us-east-2
```
- Result
  - build will succeed
  - https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/2624231951
  - image is pushed to *us-east-2*

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
