### PR TITLE
remove deprecated set-output command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,6 @@ runs:
       run: |
         $versionNumber = "${env:GITVERSION_NUGETVERSION}.${env:GITHUB_RUN_NUMBER}"
         Write-Host "Setting environment variable IMAGE_VERSION to: $versionNumber"
-        echo "::set-output name=image-version::$versionNumber"
+        echo "image-version=${versionNumber}" >> $env:GITHUB_OUTPUT
         Add-Content -Path ${env:GITHUB_ENV} -Encoding utf8 -Value "IMAGE_VERSION=$versionNumber"
         Add-Content -Path ${env:GITHUB_ENV} -Encoding utf8 -Value "OCTOPUS_RELEASE_VERSION=$versionNumber"


### PR DESCRIPTION
# Description

Remove deprecated set-output command from action.yaml

Fixes [#2033](https://usxpress.atlassian.net/browse/CLOUD-2033)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Updated references for actions-setup in [terraform-variant-apps](https://github.com/variant-inc/terraform-variant-apps/blob/f/cloud-2033-set-output/.github/workflows/octopus-package-push.yaml#L28) and in [demo-app](https://github.com/variant-inc/demo-python-flask-variant-api/blob/demo/luka-2/.github/workflows/octo-push.yaml#L20)

Updated terraform-variant-apps package version in [demo app](https://github.com/variant-inc/demo-python-flask-variant-api/blob/demo/luka-2/.github/workflows/octo-push.yaml#L40)

Check that build and deploy went ok.
[GH actions](https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/4085193479) (no more warning about deprecated set-output command compared to [sample run](https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/4067699285) from before)
[Octopus](https://octopus.apps.ops-drivevariant.com/app#/Spaces-2?projectName=luka) (API failing for other reasons)

- [x] Sanity Testing

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
