### PR TITLE
calculate base64 of Azure DevOps PAT

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,13 @@ runs:
     - shell: pwsh
       run: ${{ github.action_path }}/scripts/convertSecretsEnv.ps1
 
+    - name: Convert azure token into base64 encoded
+      shell: bash
+      run: |
+        AZ_DEVOPS_BASE64_PAT=$(echo -n ${{ env.AZ_DEVOPS_PAT }} | base64)
+        echo "::add-mask::$AZ_DEVOPS_BASE64_PAT"
+        echo "AZ_DEVOPS_BASE64_PAT=$AZ_DEVOPS_BASE64_PAT" >> $GITHUB_ENV
+
     - name: Checkout
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
# Description

Modify actions-setup to calculate base64 of Azure DevOps PAT

Fixes [#2498](https://usxpress.atlassian.net/browse/CLOUD-2498)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing 
- Tested with exporting env variable "AZ_DEVOPS_BASE65_PAT" 
   https://github.com/variant-inc/iaac-mongodb-atlas/actions/runs/8820061826/job/24212775510 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
