### PR TITLE
get env from aws parameter store

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,11 @@ runs:
     - shell: pwsh
       run: ${{ github.action_path }}/scripts/convertSecretsEnv.ps1
 
+    - name: Get AWS Parameter store env
+      shell: bash
+      run: |
+        ${{ github.action_path }}/scripts/getAWSParameter.sh arn:aws:ssm:us-east-2:108141096600:parameter/actions-envs
+
     - name: Convert azure token into base64 encoded
       shell: bash
       run: |

--- a/scripts/getAWSParameter.sh
+++ b/scripts/getAWSParameter.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Set the parameter name (adjust this to your actual parameter)
+PARAM_NAME=$1
+
+# Retrieve the value from AWS SSM Parameter Store (adjust the region as needed)
+PARAM_VALUE=$(aws ssm get-parameter --name "$PARAM_NAME" --query "Parameter.Value" --output text)
+
+# Check if the parameter retrieval was successful
+if ! PARAM_VALUE=$(aws ssm get-parameter --name "$PARAM_NAME" --query "Parameter.Value" --output text); then
+	echo "Failed to retrieve parameter from AWS SSM Parameter Store."
+	exit 1
+fi
+
+# Split the value by commas and store it in an array
+IFS=',' read -ra PARAMS <<<"$PARAM_VALUE"
+
+# Loop through each key-value pair in the array
+for PARAM in "${PARAMS[@]}"; do
+	# Split each element by '=' into key and value
+	IFS='=' read -r KEY VALUE <<<"$PARAM"
+
+	# Handle any potential spaces or special characters
+	KEY=$(echo "$KEY" | xargs)     # Remove leading/trailing whitespace
+	VALUE=$(echo "$VALUE" | xargs) # Remove leading/trailing whitespace
+
+	# Optionally, export them as environment variables
+	ENV_VAR_NAME=$(echo "$KEY" | tr '[:lower:]' '[:upper:]') # Convert key to uppercase for env var
+	echo "$ENV_VAR_NAME"="$VALUE" >>"$GITHUB_ENV"
+done


### PR DESCRIPTION
# Description

Some parameters that are not actually secret should be transferred to parameter store to avoid getting masked unintentionally.

Fixes [#2612](https://usxpress.atlassian.net/browse/CLOUD-2612)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
<!-- markdownlint-disable-next-line MD013 -->
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

https://github.com/variant-inc/demo-python-flask-variant-api/actions/runs/11895538230/job/33178050741

<img width="1137" alt="image" src="https://github.com/user-attachments/assets/f0ad2910-a1a9-4d18-9812-345c454a2c30">

- [ ] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
