### PR TITLE
fix: base64 encoding of AZ_DEVOPS_PAT

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
     - name: Convert azure token into base64 encoded
       shell: bash
       run: |
-        AZ_DEVOPS_BASE64_PAT=$(echo -n ${{ env.AZ_DEVOPS_PAT }} | base64)
+        AZ_DEVOPS_BASE64_PAT=$(echo -n ${{ env.AZ_DEVOPS_PAT }} | base64 -w 0)
         echo "::add-mask::$AZ_DEVOPS_BASE64_PAT"
         echo "AZ_DEVOPS_BASE64_PAT=$AZ_DEVOPS_BASE64_PAT" >> $GITHUB_ENV
 


### PR DESCRIPTION
# Description

### **Merge and update token before 13.3.2025 as that's when old token is expiring.**

Fix base64 encode of Azure DevOps PAT as new tokens are longer and encoded text was getting split which caused error.
[Example of error run](https://github.com/variant-inc/sample-dotnet-api/actions/runs/13628445991/job/38091132495)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
<!-- markdownlint-disable-next-line MD013 -->
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested with this branch ran in sample-demo repo.
[Success run](https://github.com/variant-inc/sample-dotnet-api/actions/runs/13628445991/job/38094055782)

Token used for testing was revoked and new one is ready to be replaced in actions-secret once this is merged.

- [ ] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
